### PR TITLE
Script with `lang="ts"` should be typescript-ed

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ module.exports = {
         loader: 'vue-loader',
         options: {
           loaders: {
+            ts: 'ts-loader',
             // Since sass-loader (weirdly) has SCSS as its default parse mode, we map
             // the "scss" and "sass" values for the lang attribute to the right configs here.
             // other preprocessors should work out of the box, no loader config like this necessary.


### PR DESCRIPTION
Otherwise build with `.vue` component files will fail.