### PR TITLE
Update documentation to Vue-loader 15.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ We'll need to add a `webpack.config.js` to bundle our app.
 ```js
 var path = require('path')
 var webpack = require('webpack')
+const VueLoaderPlugin = require('vue-loader/lib/plugin')
 
 module.exports = {
   entry: './src/index.ts',
@@ -134,6 +135,13 @@ module.exports = {
         options: {
           name: '[name].[ext]?[hash]'
         }
+      },
+      {
+        test: /\.css$/,
+        use: [
+          'vue-style-loader',
+          'css-loader'
+        ]
       }
     ]
   },
@@ -150,7 +158,11 @@ module.exports = {
   performance: {
     hints: false
   },
-  devtool: '#eval-source-map'
+  devtool: '#eval-source-map',
+  plugins: [
+    // make sure to include the plugin for the magic
+    new VueLoaderPlugin()
+  ]
 }
 
 if (process.env.NODE_ENV === 'production') {


### PR DESCRIPTION
If you follow this tutorial today you will run into errors as the vue loader was updated to version 15 a month ago and requires a couple additional configuration settings not found in the current documentation