### PR TITLE
Vue loader v15 changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,10 @@ We strongly recommend using TypeScript's stricter options for a better experienc
 We'll need to add a `webpack.config.js` to bundle our app.
 
 ```js
+
 var path = require('path')
 var webpack = require('webpack')
+var VueLoaderPlugin = require('vue-loader/lib/plugin')
 
 module.exports = {
   entry: './src/index.ts',
@@ -104,19 +106,15 @@ module.exports = {
     publicPath: '/dist/',
     filename: 'build.js'
   },
+  plugins: [
+    new VueLoaderPlugin()
+  ],
   module: {
     rules: [
       {
         test: /\.vue$/,
         loader: 'vue-loader',
         options: {
-          loaders: {
-            // Since sass-loader (weirdly) has SCSS as its default parse mode, we map
-            // the "scss" and "sass" values for the lang attribute to the right configs here.
-            // other preprocessors should work out of the box, no loader config like this necessary.
-            'scss': 'vue-style-loader!css-loader!sass-loader',
-            'sass': 'vue-style-loader!css-loader!sass-loader?indentedSyntax',
-          }
           // other vue-loader options go here
         }
       },
@@ -134,6 +132,27 @@ module.exports = {
         options: {
           name: '[name].[ext]?[hash]'
         }
+      },
+      {
+        test: /\.scss$/,
+        use: [
+          'vue-style-loader',
+          'css-loader',
+          'sass-loader'
+        ]
+      },
+      {
+        test: /\.sass$/,
+        use: [
+          'vue-style-loader',
+          'css-loader',
+          {
+            loader: 'sass-loader',
+            options: {
+              indentedSyntax: true
+            }
+          }
+        ]
       }
     ]
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,3 @@
-
 var path = require('path')
 var webpack = require('webpack')
 var VueLoaderPlugin = require('vue-loader/lib/plugin')

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 
 var path = require('path')
 var webpack = require('webpack')
+var VueLoaderPlugin = require('vue-loader/lib/plugin')
 
 module.exports = {
   entry: './src/index.ts',
@@ -9,19 +10,15 @@ module.exports = {
     publicPath: '/dist/',
     filename: 'build.js'
   },
+  plugins: [
+    new VueLoaderPlugin()
+  ],
   module: {
     rules: [
       {
         test: /\.vue$/,
         loader: 'vue-loader',
         options: {
-          loaders: {
-            // Since sass-loader (weirdly) has SCSS as its default parse mode, we map
-            // the "scss" and "sass" values for the lang attribute to the right configs here.
-            // other preprocessors should work out of the box, no loader config like this necessary.
-            'scss': 'vue-style-loader!css-loader!sass-loader',
-            'sass': 'vue-style-loader!css-loader!sass-loader?indentedSyntax',
-          }
           // other vue-loader options go here
         }
       },
@@ -39,6 +36,27 @@ module.exports = {
         options: {
           name: '[name].[ext]?[hash]'
         }
+      },
+      {
+        test: /\.scss$/,
+        use: [
+          'vue-style-loader',
+          'css-loader',
+          'sass-loader'
+        ]
+      },
+      {
+        test: /\.sass$/,
+        use: [
+          'vue-style-loader',
+          'css-loader',
+          {
+            loader: 'sass-loader',
+            options: {
+              indentedSyntax: true
+            }
+          }
+        ]
       }
     ]
   },


### PR DESCRIPTION
Vue-loader recently updated to v15 and has some relevant breaking changes: https://vue-loader.vuejs.org/migrating.html#notable-breaking-changes

- Vue Loader v15 now requires an accompanying webpack plugin to function properly
- Vue Loader v15 now uses a different strategy to infer loaders to use for language blocks. Essentially language blocks like `<style lang="sass">` will be treated as if a `.sass` file was loaded.

V15 is the version installed when you run the `npm install` command listed in the README. 

This PR should fix the `webpack.config.js` support for vue-loader v15 and updates the README to reflect the new webpack config.