### PR TITLE
webpack-cli is required to run the build script - should be added to the install command in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ You can always go back and change these in the `package.json` file that's been g
 Ensure TypeScript, Webpack, Vue and the necessary loaders are installed.
 
 ```sh
-npm install --save-dev typescript webpack ts-loader css-loader vue vue-loader vue-template-compiler
+npm install --save-dev typescript webpack webpack-cli ts-loader css-loader vue vue-loader vue-template-compiler
 ```
 
 Webpack is a tool that will bundle your code and optionally all of its dependencies into a single `.js` file.


### PR DESCRIPTION
The `webpack-cli` package is a required dependency for the `build` script in the README. When you run the `build` script it will ask you to install `webpack-cli`, so it makes sense to add the package to the `npm install` command listed in the README.