### PR TITLE
Add webpack-cli to list of dependencies installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ You can always go back and change these in the `package.json` file that's been g
 Ensure TypeScript, Webpack, Vue and the necessary loaders are installed.
 
 ```sh
-npm install --save-dev typescript webpack ts-loader css-loader vue vue-loader vue-template-compiler
+npm install --save-dev typescript webpack webpack-cli ts-loader css-loader vue vue-loader vue-template-compiler
 ```
 
 Webpack is a tool that will bundle your code and optionally all of its dependencies into a single `.js` file.


### PR DESCRIPTION
Without webpack-cli included earlier, you'll be prompted to install it when you run ```npm run build``` and the index.html won't be generated correctly.